### PR TITLE
Use csv's zero-copy API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -153,12 +153,12 @@ fn run(args: &Args) -> Result<()> {
                 csv::NextField::Data(data) => {
                     if rows == 0 {
                         let mut column = Vec::with_capacity(cmp::max(1024, data.len()));
-                        column.extend_from_slice(data);
+                        column.extend(data);
                         columns.push(column);
                     } else if column_idx < columns.len() {
                         let column = &mut columns[column_idx];
                         column.clear();
-                        column.extend_from_slice(data);
+                        column.extend(data);
                     }
                     column_idx += 1;
                 }


### PR DESCRIPTION
While our use is not zero-copy, it allows us to avoid some re-allocations by reusing existing vectors.

This achieves a larger speedup in Rust 1.15, because of rust-lang/rust#38182, which specializes `Vec<T>::extend` when `T : Copy`