### PR TITLE
Only call a row bad if it has *more* than the expected cols

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ fn run() -> Result<()> {
                 true
             }
             // We know how many columns we expect, and it matches.
-            Some(expected) if record.len() == expected => true,
+            Some(expected) if record.len() <= expected => true,
             // The current row is weird.
             Some(_) => false,
         };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -71,7 +71,7 @@ fn bad_rows() {
         good_rows.push_str("1,2,3\n");
     }
     let mut bad_rows = good_rows.clone();
-    bad_rows.push_str("1,2\n");
+    bad_rows.push_str("1,2,3,4\n");
 
     let testdir = TestDir::new("scrubcsv", "bad_rows");
     let output = testdir.cmd()
@@ -87,7 +87,7 @@ fn too_many_bad_rows() {
     let output = testdir.cmd()
         .output_with_stdin("\
 a,b,c
-1,2
+1,2,3,4
 ")
         .expect("could not run scrubcsv");
     assert!(!output.status.success());


### PR DESCRIPTION
Previously, we also called it bad if it had *less*. This happens all the time in good csvs and is fine.