### PR TITLE
Modernize `scrubcsv` a bit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": true
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,26 +26,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,11 +44,6 @@ dependencies = [
 [[package]]
 name = "byteorder"
 version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "cc"
-version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -125,15 +100,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -249,11 +215,6 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,7 +227,6 @@ dependencies = [
  "cli_test_dir 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -373,11 +333,6 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,19 +372,15 @@ dependencies = [
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
-"checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
-"checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cli_test_dir 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc63338a59538d4f4b767dfb6082e4d26736aadb5100894b76039a04d6ad519"
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-"checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
@@ -446,7 +397,6 @@ dependencies = [
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
-"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
@@ -461,7 +411,6 @@ dependencies = [
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ opt-level = 3
 clap = "2.33.0"
 csv = "1"
 env_logger = "0.7"
-error-chain = "0.12"
 humansize = "1.0.1"
 lazy_static = "1.2.0"
 libc = "0.2.18"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,24 +1,81 @@
-//! Error-handling support implemented using the `[error-chain][]` crate.
+//! Error-handling support. This emulates libraries like `error-chain` (very
+//! deprecated), `failure` (somewhat deprecated) and `snafu` (currently
+//! recommended, but I'm starting to see a pattern here).
 //!
-//! [error-chain]: https://docs.rs/error-chain
+//! I just wanted to see how hard it was to roll an nice error API from scratch
+//! instead of depending on an unstable third-party library.
 
-use csv;
-use std::io;
+use std::{error, fmt, result};
 
-// Declare nicer `Error` and `Result` types.  This is a macro that
-// generates a lot of boilerplate code for us.
-error_chain! {
-    // Error types from other libraries that we want to just wrap
-    // automatically.
-    foreign_links {
-        Csv(csv::Error);
-        Io(io::Error);
+/// Our error type. We used a boxed dynamic error because we don't care much
+/// about the details and we're only going to print it for the user anyways.
+pub type Error = Box<dyn error::Error + 'static>;
+
+/// Our custom `Result` type. Defaults the `E` parameter to our error type.
+pub type Result<T, E = Error> = result::Result<T, E>;
+
+/// Human-readable context for another error.
+#[derive(Debug)]
+pub struct Context {
+    context: String,
+    source: Error,
+}
+
+impl fmt::Display for Context {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.context.fmt(f)
+    }
+}
+
+impl error::Error for Context {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+/// Extend `Result` with methods that add context to errors.
+pub trait ResultExt<T, E>: Sized {
+    /// If this result is an error, wrap that error with `context`.
+    fn context<C>(self, context: C) -> Result<T>
+    where
+        C: Into<String>,
+    {
+        self.with_context(|_| context.into())
     }
 
-    errors {
-        CannotParseCharacter(specifier: String) {
-            description("cannot parse character specifier")
-            display("cannot parse character specifier: '{}'", specifier)
-        }
+    /// If this result is an error, call `build_context` and wrap the error in
+    /// that context.
+    fn with_context<C, F>(self, build_context: F) -> Result<T>
+    where
+        C: Into<String>,
+        F: FnOnce(&E) -> C;
+}
+
+impl<T, E: error::Error + 'static> ResultExt<T, E> for Result<T, E> {
+    fn with_context<C, F>(self, build_context: F) -> Result<T>
+    where
+        C: Into<String>,
+        F: FnOnce(&E) -> C,
+    {
+        self.map_err(|err| {
+            Box::new(Context {
+                context: build_context(&err).into(),
+                source: Box::new(err),
+            }) as Error
+        })
     }
+}
+
+/// Format a string and return it as an `Error`. We use a macro to do this,
+/// because that's the only way to declare `format!`-like syntax in Rust.
+#[macro_export]
+macro_rules! format_err {
+    ($format_str:literal) => ({
+        let err: $crate::errors::Error = format!($format_str).into();
+        err
+    });
+    ($format_str:literal, $($arg:expr),*) => ({
+        let err: $crate::errors::Error = format!($format_str, $($arg),*).into();
+        err
+    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,8 @@ struct Opt {
     replace_newlines: bool,
 
     /// Drop any rows where the specified column is empty or NULL. Can be passed
-    /// more than once.
+    /// more than once. Useful for cleaning primary key columns before
+    /// upserting.
     #[structopt(value_name = "COL", long = "drop-row-if-null")]
     drop_row_if_null: Vec<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn run() -> Result<()> {
     if let Some(delimiter) = opt.delimiter.char() {
         rdr_builder.delimiter(delimiter);
     } else {
-        return Err(format_err!("field delimiter is required"))?;
+        return Err(format_err!("field delimiter is required"));
     }
     // Configure our quote character.
     if let Some(quote) = opt.quote.char() {
@@ -185,7 +185,6 @@ fn run() -> Result<()> {
                 .any(|requried_name| requried_name.as_bytes() == name)
         })
         .collect::<Vec<bool>>();
-    drop(hdr);
 
     // Keep track of total rows and malformed rows seen. We count the header as
     // a row for backwards compatibility.

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,8 @@ struct Opt {
     )]
     delimiter: CharSpecifier,
 
-    /// Convert values matching NULL_REGEX to an empty string.
+    /// Convert values matching NULL_REGEX to an empty string. For a case-insensitive
+    /// match, use `(?i)`: `--null '(?i)NULL'`.
     #[structopt(value_name = "NULL_REGEX", short = "n", long = "null")]
     null: Option<String>,
 
@@ -71,8 +72,8 @@ struct Opt {
     #[structopt(long = "replace-newlines")]
     replace_newlines: bool,
 
-    // Drop any rows where the specified column is empty or NULL. Can be passed
-    // more than once.
+    /// Drop any rows where the specified column is empty or NULL. Can be passed
+    /// more than once.
     #[structopt(value_name = "COL", long = "drop-row-if-null")]
     drop_row_if_null: Vec<String>,
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,27 +1,46 @@
 //! Miscellaneous utilities.
 
+use std::str::FromStr;
+
 use crate::errors::*;
 
-/// Parse a character specifier and return a single-byte character.
-pub fn parse_char_specifier(specifier: &str) -> Result<Option<u8>> {
-    if specifier.as_bytes().len() == 1 {
-        Ok(Some(specifier.as_bytes()[0]))
-    } else {
-        match specifier {
-            // For convenience so users to can type `"\t"` in most shells
-            // instead of trying to type a tab literal. `xsv` supports this,
-            // too.
-            r"\t" => Ok(Some(b'\t')),
-            "none" => Ok(None),
-            _ => Err(ErrorKind::CannotParseCharacter(specifier.to_owned()).into()),
+/// Specifies an optional single-byte character used to configure our CSV
+/// parser.
+#[derive(Debug)]
+pub struct CharSpecifier(Option<u8>);
+
+impl CharSpecifier {
+    /// Return the specified character, if any.
+    pub fn char(&self) -> Option<u8> {
+        self.0
+    }
+}
+
+impl FromStr for CharSpecifier {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<CharSpecifier> {
+        if s.as_bytes().len() == 1 {
+            Ok(CharSpecifier(Some(s.as_bytes()[0])))
+        } else {
+            match s {
+                // For convenience so users to can type `"\t"` in most shells
+                // instead of trying to type a tab literal. `xsv` supports this,
+                // too.
+                r"\t" => Ok(CharSpecifier(Some(b'\t'))),
+                "tab" => Ok(CharSpecifier(Some(b'\t'))),
+                "none" => Ok(CharSpecifier(None)),
+                _ => Err(format_err!("cannot parse character specifier: '{}'", s)),
+            }
         }
     }
 }
 
 #[test]
 fn parses_char_specifiers() {
-    assert_eq!(parse_char_specifier(",").unwrap(), Some(b','));
-    assert_eq!(parse_char_specifier("\t").unwrap(), Some(b'\t'));
-    assert_eq!(parse_char_specifier(r"\t").unwrap(), Some(b'\t'));
-    assert_eq!(parse_char_specifier(r"none").unwrap(), None);
+    assert_eq!(CharSpecifier::from_str(",").unwrap().char(), Some(b','));
+    assert_eq!(CharSpecifier::from_str("\t").unwrap().char(), Some(b'\t'));
+    assert_eq!(CharSpecifier::from_str(r"\t").unwrap().char(), Some(b'\t'));
+    assert_eq!(CharSpecifier::from_str(r"tab").unwrap().char(), Some(b'\t'));
+    assert_eq!(CharSpecifier::from_str(r"none").unwrap().char(), None);
 }


### PR DESCRIPTION
We modernize, simplify and reorganize the code, and get a 5 to 25% speed improvement on the fast path. This also fixes the incomplete `--help` messages.

We ditch the badly-obsolete `error-chain` library, and—just to get a better grasp on the new and improved Rust `Error` trait—we implement some ergonomic `.context`, `.with_context` and `format_err!` support from scratch. We're probably going to want to replace both `error-chain` and `failure` with `snafu` at some point (across many, many projects), and this gives me an idea of what will be involved.