### PR TITLE
Add `--clean-column-names`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 
 // Import from other crates.
+use csv::ByteRecord;
 use humansize::{file_size_opts, FileSize};
 use lazy_static::lazy_static;
 use log::debug;
@@ -17,10 +18,12 @@ use structopt::StructOpt;
 // Modules defined in separate files.
 #[macro_use]
 mod errors;
+mod uniquifier;
 mod util;
 
 // Import from our own crates.
 use crate::errors::*;
+use crate::uniquifier::Uniquifier;
 use crate::util::CharSpecifier;
 
 /// Use reasonably large input and output buffers. This seems to give us a
@@ -72,9 +75,14 @@ struct Opt {
     #[structopt(long = "replace-newlines")]
     replace_newlines: bool,
 
+    /// Make sure column names are unique, and use only lowercase letters, numbers
+    /// and underscores.
+    #[structopt(long = "clean-column-names")]
+    clean_column_names: bool,
+
     /// Drop any rows where the specified column is empty or NULL. Can be passed
     /// more than once. Useful for cleaning primary key columns before
-    /// upserting.
+    /// upserting. Uses the cleaned form of column names.
     #[structopt(value_name = "COL", long = "drop-row-if-null")]
     drop_row_if_null: Vec<String>,
 
@@ -169,11 +177,29 @@ fn run() -> Result<()> {
         .buffer_capacity(BUFFER_SIZE)
         .from_writer(output);
 
-    // Calculate the number of expected columns.
-    let hdr = rdr.byte_headers().context("cannot read headers")?;
-    let expected_cols = hdr.len();
+    // Get our header and, if we were asked, make sure all the column names are unique.
+    let mut hdr = rdr
+        .byte_headers()
+        .context("cannot read headers")?
+        .to_owned();
+    if opt.clean_column_names {
+        let mut uniquifier = Uniquifier::default();
+        let mut new_hdr = ByteRecord::default();
+        for col in hdr.into_iter() {
+            // Convert from bytes to UTF-8, make unique (and clean), and convert back to bytes.
+            let col = String::from_utf8_lossy(col);
+            let col = uniquifier.unique_id_for(&col)?.to_owned();
+            new_hdr.push_field(col.as_bytes());
+        }
+        hdr = new_hdr;
+    }
+
+    // Write our header to our output.
     wtr.write_byte_record(&hdr)
         .context("cannot write headers")?;
+
+    // Calculate the number of expected columns.
+    let expected_cols = hdr.len();
 
     // Just in case --drop-row-if-null was passed, precompute which columns are
     // required to contain a value.

--- a/src/uniquifier.rs
+++ b/src/uniquifier.rs
@@ -1,0 +1,83 @@
+//! Make unique identifiers from messy strings.
+//!
+//! Imported from `dbcrossbar`, another open source Faraday project with
+//! the same copyright holder and license.
+
+use std::collections::HashSet;
+
+use crate::Result;
+
+/// Turns arbitrary Unicode names into unique, lowercase ASCII identifiers. All
+/// identifiers start with an underscore or a lowercase ASCII letter, followed
+/// by zero or more underscores, lowercase ASCII letters and digits.
+#[derive(Debug, Default)]
+pub(crate) struct Uniquifier {
+    /// Identifiers that we have already generated.
+    used: HashSet<String>,
+}
+
+impl Uniquifier {
+    /// Given a `name`, return an idenfitier
+    pub(crate) fn unique_id_for<'a>(&mut self, name: &'a str) -> Result<&str> {
+        let id = name_to_lowercase_id(name);
+        if self.used.insert(id.to_owned()) {
+            Ok(&self.used.get(&id).expect("just verified id was present")[..])
+        } else {
+            let mut offset = 1;
+            while offset < 50 {
+                offset += 1;
+                let alt_id = format!("{}_{}", id, offset);
+                if self.used.insert(alt_id.to_owned()) {
+                    return Ok(&self
+                        .used
+                        .get(&alt_id)
+                        .expect("just verified alt_id was present")[..]);
+                }
+            }
+            Err(format_err!("too many column name collisions"))
+        }
+    }
+}
+
+#[test]
+fn uniquifier_generates_unique_ids() {
+    let examples = &[
+        ("a", "a"),
+        ("A", "a_2"),
+        ("a_2", "a_2_2"), // Sneaky.
+        ("B", "b"),
+    ];
+    let mut uniqifier = Uniquifier::default();
+    for &(input, expected) in examples {
+        assert_eq!(uniqifier.unique_id_for(input).unwrap(), expected);
+    }
+}
+
+/// Given a unique string, turn it into a lower-case identifier.
+fn name_to_lowercase_id(name: &str) -> String {
+    if name.is_empty() {
+        "_".to_owned()
+    } else {
+        name.char_indices()
+            .map(|(idx, c)| {
+                if c == '_' || c.is_ascii_lowercase() {
+                    c
+                } else if c.is_ascii_uppercase() {
+                    c.to_ascii_lowercase()
+                } else if idx != 0 && c.is_ascii_digit() {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>()
+    }
+}
+
+#[test]
+fn name_to_lowercase_id_cleans_non_id_characters() {
+    let examples = &[("", "_"), ("_aA1?", "_aa1_"), ("1", "_")];
+    for &(input, expected) in examples {
+        assert_eq!(name_to_lowercase_id(input), expected);
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -153,6 +153,17 @@ fn replace_newlines() {
 }
 
 #[test]
+fn clean_column_names() {
+    let testdir = TestDir::new("scrubcsv", "clean_column_names");
+    let output = testdir
+        .cmd()
+        .arg("--clean-column-names")
+        .output_with_stdin(",,a,a\n")
+        .expect_success();
+    assert_eq!(output.stdout_str(), "_,__2,a,a_2\n");
+}
+
+#[test]
 fn drop_row_if_null() {
     let testdir = TestDir::new("scrubcsv", "replace_newlines");
     let output = testdir


### PR DESCRIPTION
This patch reuses our dbcrossbar column-name uniquifier code to optionally make column names unique (and safe for use as database identifiers).