### PR TITLE
Optionally trim whitespace from cells (fixes #8)

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -153,6 +153,17 @@ fn replace_newlines() {
 }
 
 #[test]
+fn trim_whitespace() {
+    let testdir = TestDir::new("scrubcsv", "trim_whitespace");
+    let output = testdir
+        .cmd()
+        .arg("--trim-whitespace")
+        .output_with_stdin("a,b,c,d\n 1 , 2, ,\n")
+        .expect_success();
+    assert_eq!(output.stdout_str(), "a,b,c,d\n1,2,,\n");
+}
+
+#[test]
 fn drop_row_if_null() {
     let testdir = TestDir::new("scrubcsv", "replace_newlines");
     let output = testdir


### PR DESCRIPTION
We add a `--trim-whitespace` command. This avoids using the standard `trim()` method because that method requires a UTF-8 string, and we handle UTF-8 input, so we need to roll our own.